### PR TITLE
Adds README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+# Terraform SBOM Generator
+
+A Go tool for generating Software Bill of Materials (SBOM) from Terraform configurations.
+
+## Features
+
+- Analyzes Terraform configurations to identify module dependencies
+- Supports multiple output formats: JSON, XML, CSV, TSV, SPDX, CycloneDX
+- Recursive scanning of Terraform modules
+- Command-line interface with verbose output options
+
+## Installation
+
+### Build from source
+
+```bash
+git clone <repository-url>
+cd tf-sbom
+make build
+```
+
+### Using Go install
+
+```bash
+make install
+```
+
+## Usage
+
+```
+./terraform-sbom [options] <terraform-directory>
+```
+
+### Options
+
+- `-f string`: Output format(s) - comma-separated (json, xml, csv, tsv, spdx, cyclonedx) (default "json")
+- `-o string`: Output file path base (extensions added automatically)
+- `-r`: Recursively scan for Terraform modules
+- `-v`: Verbose output
+
+### Examples
+
+Generate JSON SBOM for a Terraform configuration:
+```bash
+./terraform-sbom ./terraform
+```
+
+Generate multiple formats with custom output file:
+```bash
+./terraform-sbom -f json,spdx,cyclonedx -o sbom ./terraform
+```
+
+Recursively scan all modules with verbose output:
+```bash
+./terraform-sbom -r -v -f spdx -o sbom ./project
+```
+
+## Development
+
+### Requirements
+
+- Go 1.24+
+- Make
+
+### Commands
+
+```bash
+# Build the project
+make build
+
+# Run tests
+make test
+
+# Format code
+make fmt
+
+# Run linters
+make lint
+
+# Generate coverage report
+make coverage
+
+# Clean build artifacts
+make clean
+
+# Run all validation checks
+make validate
+```
+
+### Project Structure
+
+```
+.
+├── Makefile
+├── README.md
+├── cmd/
+│   └── terraform-sbom/ # Main application entry point
+├── internal
+│   ├── cli/            # Command-line interface handling
+│   ├── export/         # Export functionality for various formats
+│   └── sbom/           # Core SBOM generation logic and types
+```
+
+## Supported Output Formats
+
+- **JSON**: Standard JSON format
+- **XML**: XML representation
+- **CSV/TSV**: Comma/Tab-separated values
+- **SPDX**: Software Package Data Exchange format
+- **CycloneDX**: OWASP CycloneDX format
+
+## License
+
+TBD - Not sure how this works with Hashicorp BUSL. 


### PR DESCRIPTION
This pull request adds comprehensive documentation for the Terraform SBOM Generator, a Go tool designed to generate Software Bill of Materials (SBOM) from Terraform configurations. The README file now includes detailed information about features, installation, usage, development, project structure, supported output formats, and licensing.

### Documentation Enhancements:

* **Features Overview**: Highlights key capabilities such as module dependency analysis, support for multiple output formats, recursive scanning, and a command-line interface. (`README.md`, [README.mdR1-R111](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R111))
* **Installation Instructions**: Provides steps for building from source and using `make install` with Go. (`README.md`, [README.mdR1-R111](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R111))
* **Usage Examples**: Includes command-line options and examples for generating SBOMs in various formats and configurations. (`README.md`, [README.mdR1-R111](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R111))
* **Development Guidelines**: Lists required tools, build commands, testing, formatting, linting, and validation processes. (`README.md`, [README.mdR1-R111](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R111))
* **Project Structure and Supported Formats**: Describes the directory layout and supported SBOM output formats like JSON, XML, SPDX, and CycloneDX. (`README.md`, [README.mdR1-R111](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R111))