### PR TITLE
Adds filename field

### DIFF
--- a/internal/export/csv.go
+++ b/internal/export/csv.go
@@ -14,14 +14,14 @@ func exportDelimited(s *sbom.SBOM, writer io.Writer, separator rune, formatName 
 	csvWriter.Comma = separator
 
 	// Write header row
-	headers := []string{"Name", "Source", "Version", "Location"}
+	headers := []string{"Name", "Source", "Version", "Location", "Filename"}
 	if err := csvWriter.Write(headers); err != nil {
 		return fmt.Errorf("failed to write %s headers: %w", formatName, err)
 	}
 
 	// Write data rows
 	for _, module := range s.Modules {
-		record := []string{module.Name, module.Source, module.Version, module.Location}
+		record := []string{module.Name, module.Source, module.Version, module.Location, module.Filename}
 		if err := csvWriter.Write(record); err != nil {
 			return fmt.Errorf("failed to write %s record: %w", formatName, err)
 		}

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -21,7 +21,7 @@ func TestExportJSONErrors(t *testing.T) {
 	t.Run("write error", func(t *testing.T) {
 		testSBOM := &sbom.SBOM{
 			Modules: []sbom.ModuleInfo{
-				{Name: "test", Source: "test", Version: "1.0", Location: "test"},
+				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "test.tf"},
 			},
 		}
 
@@ -45,6 +45,7 @@ func TestExportJSON(t *testing.T) {
 				Source:   "terraform-aws-modules/vpc/aws",
 				Version:  "~> 5.0",
 				Location: "Module call at main.tf:10",
+				Filename: "main.tf",
 			},
 		},
 	}

--- a/internal/export/xml_test.go
+++ b/internal/export/xml_test.go
@@ -27,7 +27,7 @@ func TestExportXMLErrors(t *testing.T) {
 	t.Run("XML header write error", func(t *testing.T) {
 		testSBOM := &sbom.SBOM{
 			Modules: []sbom.ModuleInfo{
-				{Name: "test", Source: "test", Version: "1.0", Location: "test"},
+				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "test.tf"},
 			},
 		}
 
@@ -46,7 +46,7 @@ func TestExportXMLErrors(t *testing.T) {
 	t.Run("XML encoding error", func(t *testing.T) {
 		testSBOM := &sbom.SBOM{
 			Modules: []sbom.ModuleInfo{
-				{Name: "test", Source: "test", Version: "1.0", Location: "test"},
+				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "test.tf"},
 			},
 		}
 
@@ -70,12 +70,14 @@ func TestExportXML(t *testing.T) {
 				Source:   "terraform-aws-modules/vpc/aws",
 				Version:  "~> 5.0",
 				Location: "Module call at main.tf:10",
+				Filename: "main.tf",
 			},
 			{
 				Name:     "local-module",
 				Source:   "./modules/local",
 				Version:  "",
 				Location: "Module call at main.tf:20",
+				Filename: "main.tf",
 			},
 		},
 	}
@@ -244,6 +246,7 @@ func TestExportXML(t *testing.T) {
 					Source:   "github.com/example/module",
 					Version:  "v1.0.0",
 					Location: "Module call at test.tf:5",
+					Filename: "test.tf",
 				},
 			},
 		}

--- a/internal/sbom/generator.go
+++ b/internal/sbom/generator.go
@@ -49,6 +49,7 @@ func Generate(configPath string, recursive bool) (*SBOM, error) {
 				Source:   moduleCall.Source,
 				Version:  moduleCall.Version,
 				Location: fmt.Sprintf("Module call at %s:%d", moduleCall.Pos.Filename, moduleCall.Pos.Line),
+				Filename: filepath.Base(moduleCall.Pos.Filename),
 			}
 			sbom.Modules = append(sbom.Modules, moduleInfo)
 		}

--- a/internal/sbom/types.go
+++ b/internal/sbom/types.go
@@ -10,6 +10,7 @@ type ModuleInfo struct {
 	Source   string `json:"source" xml:"source"`
 	Version  string `json:"version" xml:"version"`
 	Location string `json:"location" xml:"location"`
+	Filename string `json:"filename" xml:"filename"`
 }
 
 // SBOM represents a Software Bill of Materials for Terraform configurations

--- a/internal/sbom/types_test.go
+++ b/internal/sbom/types_test.go
@@ -12,6 +12,7 @@ func TestModuleInfoSerialization(t *testing.T) {
 		Source:   "github.com/example/test-module",
 		Version:  "1.0.0",
 		Location: "Module call at main.tf:10",
+		Filename: "main.tf",
 	}
 
 	// Test JSON serialization
@@ -38,6 +39,9 @@ func TestModuleInfoSerialization(t *testing.T) {
 		}
 		if unmarshaled.Location != moduleInfo.Location {
 			t.Errorf("Location = %v, want %v", unmarshaled.Location, moduleInfo.Location)
+		}
+		if unmarshaled.Filename != moduleInfo.Filename {
+			t.Errorf("Filename = %v, want %v", unmarshaled.Filename, moduleInfo.Filename)
 		}
 	})
 
@@ -66,6 +70,9 @@ func TestModuleInfoSerialization(t *testing.T) {
 		if unmarshaled.Location != moduleInfo.Location {
 			t.Errorf("Location = %v, want %v", unmarshaled.Location, moduleInfo.Location)
 		}
+		if unmarshaled.Filename != moduleInfo.Filename {
+			t.Errorf("Filename = %v, want %v", unmarshaled.Filename, moduleInfo.Filename)
+		}
 	})
 }
 
@@ -77,12 +84,14 @@ func TestSBOMSerialization(t *testing.T) {
 				Source:   "github.com/example/module1",
 				Version:  "1.0.0",
 				Location: "Module call at main.tf:10",
+				Filename: "main.tf",
 			},
 			{
 				Name:     "module2",
 				Source:   "github.com/example/module2",
 				Version:  "2.0.0",
 				Location: "Module call at main.tf:20",
+				Filename: "main.tf",
 			},
 		},
 	}


### PR DESCRIPTION
This pull request introduces a new field, `Filename`, to the `ModuleInfo` structure, enhancing the clarity and granularity of exported SBOM (Software Bill of Materials) data. The changes ensure that the filename associated with each module is included in both the SBOM generation process and the CSV export functionality.

### Enhancements to SBOM data structure:

* [`internal/sbom/types.go`](diffhunk://#diff-c9fd567da7d92f4d4ad4ac0802d7fa04c39c8b595cc061532b9ee5d94d2d90beR13): Added a new `Filename` field to the `ModuleInfo` struct to store the base filename of the module's source file.

### Updates to SBOM generation logic:

* [`internal/sbom/generator.go`](diffhunk://#diff-3225289f23043a546862c955b5ad9e39b169f3a5d5ab4d4aacfa13d07fd5ac1fR52): Modified the `Generate` function to populate the new `Filename` field with the base name of the module's source file using `filepath.Base`.

### Improvements to CSV export functionality:

* [`internal/export/csv.go`](diffhunk://#diff-00bca05f586937c590d1f5f7a20934ce2818c6bbfba367c1723a9f954e9e6f86L17-R24): Updated the CSV export logic to include the `Filename` field in the header row and data rows, ensuring the new field is reflected in exported SBOM files.