### PR TITLE
Fully qualifies filename

### DIFF
--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -19,15 +19,15 @@ func TestExportSBOM(t *testing.T) {
 				Name:     "test-module",
 				Source:   "terraform-aws-modules/vpc/aws",
 				Version:  "~> 5.0",
-				Location: "Module call at main.tf:10",
-				Filename: "main.tf",
+				Location: "Module call at /project/main.tf:10",
+				Filename: "/project/main.tf",
 			},
 			{
 				Name:     "local-module",
 				Source:   "./modules/local",
 				Version:  "",
-				Location: "Module call at main.tf:20",
-				Filename: "main.tf",
+				Location: "Module call at /project/main.tf:20",
+				Filename: "/project/main.tf",
 			},
 		},
 	}
@@ -172,14 +172,14 @@ func TestExportSBOM(t *testing.T) {
 
 		// Check first module row
 		firstRow := lines[1]
-		if !strings.Contains(firstRow, "main.tf") {
-			t.Errorf("First CSV row should contain filename 'main.tf', got: %q", firstRow)
+		if !strings.Contains(firstRow, "/project/main.tf") {
+			t.Errorf("First CSV row should contain filename '/project/main.tf', got: %q", firstRow)
 		}
 
 		// Check second module row
 		secondRow := lines[2]
-		if !strings.Contains(secondRow, "main.tf") {
-			t.Errorf("Second CSV row should contain filename 'main.tf', got: %q", secondRow)
+		if !strings.Contains(secondRow, "/project/main.tf") {
+			t.Errorf("Second CSV row should contain filename '/project/main.tf', got: %q", secondRow)
 		}
 	})
 
@@ -227,14 +227,14 @@ func TestExportSBOM(t *testing.T) {
 
 		// Check first module row
 		firstRow := lines[1]
-		if !strings.Contains(firstRow, "main.tf") {
-			t.Errorf("First TSV row should contain filename 'main.tf', got: %q", firstRow)
+		if !strings.Contains(firstRow, "/project/main.tf") {
+			t.Errorf("First TSV row should contain filename '/project/main.tf', got: %q", firstRow)
 		}
 
 		// Check second module row
 		secondRow := lines[2]
-		if !strings.Contains(secondRow, "main.tf") {
-			t.Errorf("Second TSV row should contain filename 'main.tf', got: %q", secondRow)
+		if !strings.Contains(secondRow, "/project/main.tf") {
+			t.Errorf("Second TSV row should contain filename '/project/main.tf', got: %q", secondRow)
 		}
 	})
 

--- a/internal/export/json_test.go
+++ b/internal/export/json_test.go
@@ -21,7 +21,7 @@ func TestExportJSONErrors(t *testing.T) {
 	t.Run("write error", func(t *testing.T) {
 		testSBOM := &sbom.SBOM{
 			Modules: []sbom.ModuleInfo{
-				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "test.tf"},
+				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "/project/test.tf"},
 			},
 		}
 
@@ -44,8 +44,8 @@ func TestExportJSON(t *testing.T) {
 				Name:     "test-module",
 				Source:   "terraform-aws-modules/vpc/aws",
 				Version:  "~> 5.0",
-				Location: "Module call at main.tf:10",
-				Filename: "main.tf",
+				Location: "Module call at /project/main.tf:10",
+				Filename: "/project/main.tf",
 			},
 		},
 	}

--- a/internal/export/xml_test.go
+++ b/internal/export/xml_test.go
@@ -27,7 +27,7 @@ func TestExportXMLErrors(t *testing.T) {
 	t.Run("XML header write error", func(t *testing.T) {
 		testSBOM := &sbom.SBOM{
 			Modules: []sbom.ModuleInfo{
-				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "test.tf"},
+				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "/project/test.tf"},
 			},
 		}
 
@@ -46,7 +46,7 @@ func TestExportXMLErrors(t *testing.T) {
 	t.Run("XML encoding error", func(t *testing.T) {
 		testSBOM := &sbom.SBOM{
 			Modules: []sbom.ModuleInfo{
-				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "test.tf"},
+				{Name: "test", Source: "test", Version: "1.0", Location: "test", Filename: "/project/test.tf"},
 			},
 		}
 
@@ -69,15 +69,15 @@ func TestExportXML(t *testing.T) {
 				Name:     "test-module",
 				Source:   "terraform-aws-modules/vpc/aws",
 				Version:  "~> 5.0",
-				Location: "Module call at main.tf:10",
-				Filename: "main.tf",
+				Location: "Module call at /project/main.tf:10",
+				Filename: "/project/main.tf",
 			},
 			{
 				Name:     "local-module",
 				Source:   "./modules/local",
 				Version:  "",
-				Location: "Module call at main.tf:20",
-				Filename: "main.tf",
+				Location: "Module call at /project/main.tf:20",
+				Filename: "/project/main.tf",
 			},
 		},
 	}
@@ -245,8 +245,8 @@ func TestExportXML(t *testing.T) {
 					Name:     "single-module",
 					Source:   "github.com/example/module",
 					Version:  "v1.0.0",
-					Location: "Module call at test.tf:5",
-					Filename: "test.tf",
+					Location: "Module call at /project/test.tf:5",
+					Filename: "/project/test.tf",
 				},
 			},
 		}

--- a/internal/sbom/generator.go
+++ b/internal/sbom/generator.go
@@ -49,7 +49,7 @@ func Generate(configPath string, recursive bool) (*SBOM, error) {
 				Source:   moduleCall.Source,
 				Version:  moduleCall.Version,
 				Location: fmt.Sprintf("Module call at %s:%d", moduleCall.Pos.Filename, moduleCall.Pos.Line),
-				Filename: filepath.Base(moduleCall.Pos.Filename),
+				Filename: moduleCall.Pos.Filename,
 			}
 			sbom.Modules = append(sbom.Modules, moduleInfo)
 		}

--- a/internal/sbom/generator_test.go
+++ b/internal/sbom/generator_test.go
@@ -919,35 +919,32 @@ module "outputs_module" {
 		for _, module := range result.Modules {
 			modulesByName[module.Name] = module
 
-			// Verify filename is not empty and is just the basename
+			// Verify filename is not empty and contains full path
 			if module.Filename == "" {
 				t.Errorf("Module %s has empty filename", module.Name)
 			}
-			if strings.Contains(module.Filename, "/") {
-				t.Errorf("Module %s filename should be basename only, got: %s", module.Name, module.Filename)
-			}
 		}
 
-		// Check specific filename extraction
+		// Check specific filename extraction - should contain full path ending with expected file
 		if mainMod, exists := modulesByName["main_module"]; exists {
-			if mainMod.Filename != "main.tf" {
-				t.Errorf("main_module.Filename = %v, want 'main.tf'", mainMod.Filename)
+			if !strings.HasSuffix(mainMod.Filename, "/main.tf") {
+				t.Errorf("main_module.Filename = %v, want path ending with '/main.tf'", mainMod.Filename)
 			}
 		} else {
 			t.Error("main_module not found")
 		}
 
 		if varsMod, exists := modulesByName["vars_module"]; exists {
-			if varsMod.Filename != "variables.tf" {
-				t.Errorf("vars_module.Filename = %v, want 'variables.tf'", varsMod.Filename)
+			if !strings.HasSuffix(varsMod.Filename, "/variables.tf") {
+				t.Errorf("vars_module.Filename = %v, want path ending with '/variables.tf'", varsMod.Filename)
 			}
 		} else {
 			t.Error("vars_module not found")
 		}
 
 		if outputsMod, exists := modulesByName["outputs_module"]; exists {
-			if outputsMod.Filename != "outputs.tf" {
-				t.Errorf("outputs_module.Filename = %v, want 'outputs.tf'", outputsMod.Filename)
+			if !strings.HasSuffix(outputsMod.Filename, "/outputs.tf") {
+				t.Errorf("outputs_module.Filename = %v, want path ending with '/outputs.tf'", outputsMod.Filename)
 			}
 		} else {
 			t.Error("outputs_module not found")

--- a/internal/sbom/types_test.go
+++ b/internal/sbom/types_test.go
@@ -11,8 +11,8 @@ func TestModuleInfoSerialization(t *testing.T) {
 		Name:     "test-module",
 		Source:   "github.com/example/test-module",
 		Version:  "1.0.0",
-		Location: "Module call at main.tf:10",
-		Filename: "main.tf",
+		Location: "Module call at /project/main.tf:10",
+		Filename: "/project/main.tf",
 	}
 
 	// Test JSON serialization
@@ -83,15 +83,15 @@ func TestSBOMSerialization(t *testing.T) {
 				Name:     "module1",
 				Source:   "github.com/example/module1",
 				Version:  "1.0.0",
-				Location: "Module call at main.tf:10",
-				Filename: "main.tf",
+				Location: "Module call at /project/main.tf:10",
+				Filename: "/project/main.tf",
 			},
 			{
 				Name:     "module2",
 				Source:   "github.com/example/module2",
 				Version:  "2.0.0",
-				Location: "Module call at main.tf:20",
-				Filename: "main.tf",
+				Location: "Module call at /project/main.tf:20",
+				Filename: "/project/main.tf",
 			},
 		},
 	}


### PR DESCRIPTION
This pull request updates the handling of file paths in the SBOM (Software Bill of Materials) generation and testing code. The changes ensure that file paths include the full path instead of just the basename, improving clarity and consistency across various serialization formats (JSON, XML, CSV, and TSV). Additionally, the test cases have been updated to reflect the new path format.

### SBOM Generation Changes:
* Updated `Filename` in `func Generate` to store the full file path instead of the basename. (`internal/sbom/generator.go`)

### Test Updates for Serialization Formats:
* Modified test cases for JSON, XML, and SBOM serialization to use full file paths in `Filename` and `Location` fields. (`internal/export/json_test.go`, `internal/export/xml_test.go`, `internal/sbom/types_test.go`) [[1]](diffhunk://#diff-d4f5480338b56808dd4167abe1f2575d5d678fd861f5aedfbf134177657efbaeL24-R24) [[2]](diffhunk://#diff-bf64942080cd8045f50a9c59c2bf1e17b3f4ca7719a66f12e55eda3e9ec72b38L30-R30) [[3]](diffhunk://#diff-7394a7ae2fe89297fdd297752b9bc46d607522c9b3c2658dcd890914c7879ba3L14-R15)

### Test Updates for Output Formats:
* Updated CSV and TSV tests to validate the presence of full file paths in `Filename` fields. (`internal/export/export_test.go`) [[1]](diffhunk://#diff-24c524651ba2f96e57daf9e3055a2881d7e6b05858481eb5628b6ba78d4c52bcL22-R30) [[2]](diffhunk://#diff-24c524651ba2f96e57daf9e3055a2881d7e6b05858481eb5628b6ba78d4c52bcL175-R182) [[3]](diffhunk://#diff-24c524651ba2f96e57daf9e3055a2881d7e6b05858481eb5628b6ba78d4c52bcL230-R237)

### SBOM Generator Test Updates:
* Adjusted `generator_test.go` to verify that `Filename` contains the full path and ends with the expected file name. (`internal/sbom/generator_test.go`)